### PR TITLE
Construct tdigest fxn

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
@@ -137,19 +138,30 @@ public final class TDigestFunctions
         return TDIGEST_CENTROIDS_ROW_TYPE.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
     }
 
-    @ScalarFunction(value = "structure_tdigest", visibility = EXPERIMENTAL)
+    @ScalarFunction(value = "construct_tdigest", visibility = EXPERIMENTAL)
     @Description("Return a serialized TDigest, given the raw representation.")
     @SqlType("varbinary")
-    public static Block structureTDigest(@SqlType("row(centroid_means array(double), centroid_weights array(integer), compression double, min double, max double, sum double, count bigint)") TDIGEST_CENTROIDS_ROW_TYPE input)
+    public static Block constructTDigest(
+            @SqlType("ARRAY<DOUBLE>") ArrayType centroidMeans,
+            @SqlType("ARRAY<BIGINT>") ArrayType centroidWeights,
+            @SqlType("DOUBLE") double compression,
+            @SqlType("DOUBLE") double min,
+            @SqlType("DOUBLE") double max,
+            @SqlType("DOUBLE") double sum,
+            @SqlType("BIGINT") int count)
     {
-        TDigest tDigest = createTDigest(input.compression);
-
-        tDigest.setMinMax(input.min, input.max);
-        tDigest.setSum(input.sum);
-        tDigest.totalWeight = input.sum; // TODO: what should totalWeight be?
-        tDigest.activeCentroids = input.count;
-        tDigest.weight = input.centroid_weights;
-        tDigest.mean = input.centroid_means;
+        Slice slice = new Slice(
+                0,
+                0,
+                min,
+                max,
+                sum,
+                compression,
+                sum, // this is what totalWeight is set to. Is this right?
+                count, // active centroids
+                centroidWeights,
+                centroidMeans);
+        TDigest tDigest = createTDigest(slice);
 
         SqlVarbinary result = new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " ");
         return result;

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -159,6 +159,26 @@ public class TDigest
         return new TDigest(compression);
     }
 
+    public static TDigest createTDigest(
+            double[] centroidMeans,
+            double[] centroidWeights,
+            double compression,
+            double min,
+            double max,
+            double sum,
+            int count)
+    {
+        TDigest tDigest = new TDigest(compression);
+        tDigest.setMinMax(min, max);
+        tDigest.setSum(sum);
+        tDigest.totalWeight = sum; // TODO: what should totalWeight be?
+        tDigest.activeCentroids = count;
+        tDigest.weight = centroidWeights;
+        tDigest.mean = centroidMeans;
+
+        return tDigest;
+    }
+
     public static TDigest createTDigest(Slice slice)
     {
         if (slice == null) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -592,7 +592,8 @@ public class TestTDigestFunctions
         double sum = values.stream().reduce(0.0d, Double::sum);
         long count = values.size();
 
-        String tdigestStr = new SqlVarbinary(tDigest.serialize().getBytes()).toString().replaceAll("\\s+", " ");
+        SqlVarbinary sqlVarbinary = new SqlVarbinary(tDigest.serialize().getBytes());
+        String tdigestStr = sqlVarbinary.toString().replaceAll("\\s+", " ");
 
         String sql = format("construct_tdigest(destructure_tdigest(CAST(X'%s' AS tdigest(%s))).centroid_means, CAST(destructure_tdigest(CAST(X'%s' AS tdigest(%s))).centroid_weights AS ARRAY<DOUBLE>), destructure_tdigest(CAST(X'%s' AS tdigest(%s))).compression, destructure_tdigest(CAST(X'%s' AS tdigest(%s))).min, destructure_tdigest(CAST(X'%s' AS tdigest(%s))).max, destructure_tdigest(CAST(X'%s' AS tdigest(%s))).sum, destructure_tdigest(CAST(X'%s' AS tdigest(%s))).count)",
                 tdigestStr,
@@ -610,10 +611,12 @@ public class TestTDigestFunctions
                 tdigestStr,
                 DOUBLE);
 
-        functionAssertions.selectSingleValue(
+        SqlVarbinary constructedSqlVarbinary = functionAssertions.selectSingleValue(
                 sql,
                 TDIGEST_DOUBLE,
                 SqlVarbinary.class);
+
+        assertEquals(constructedSqlVarbinary, sqlVarbinary);
     }
 
     // disabled because test takes almost 10s

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -415,6 +415,35 @@ public class TestTDigestFunctions
     }
 
     @Test
+    public void testConstructTDigest()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        ImmutableList<Double> values = ImmutableList.of(0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, 9.0d);
+        values.stream().forEach(tDigest::add);
+
+        List<Integer> weights = Collections.nCopies(values.size(), 1);
+        double compression = Double.valueOf(STANDARD_COMPRESSION_FACTOR);
+        double min = values.stream().reduce(Double.POSITIVE_INFINITY, Double::min);
+        double max = values.stream().reduce(Double.NEGATIVE_INFINITY, Double::max);
+        double sum = values.stream().reduce(0.0d, Double::sum);
+        long count = values.size();
+
+        String sql = format("construct_tdigest(CAST(ROW(%s, %s, %s, %s, %s, %s, %s) AS ROW(centroid_means ARRAY<DOUBLE>, centroid_weights ARRAY<BIGINT>, compression DOUBLE, min DOUBLE, max DOUBLE, sum DOUBLE, count BIGINT)))",
+                values,
+                weights,
+                compression,
+                min,
+                max,
+                sum,
+                count);
+
+        functionAssertions.assertFunction(
+                sql,
+                SqlVarbinary,
+                new SqlVarbinary(tDigest.serialize().getBytes()));
+    }
+
+    @Test
     public void testDestructureTDigest()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
@@ -450,6 +479,35 @@ public class TestTDigestFunctions
                 format("%s.centroid_weights", sql),
                 new ArrayType(INTEGER),
                 weights);
+    }
+
+    @Test
+    public void testConstructTDigestLarge()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        ImmutableList<Double> values = ImmutableList.of(0.0d, 1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, 9.0d);
+        values.stream().forEach(tDigest::add);
+
+        List<Integer> weights = Collections.nCopies(values.size(), 1);
+        double compression = Double.valueOf(STANDARD_COMPRESSION_FACTOR);
+        double min = values.stream().reduce(Double.POSITIVE_INFINITY, Double::min);
+        double max = values.stream().reduce(Double.NEGATIVE_INFINITY, Double::max);
+        double sum = values.stream().reduce(0.0d, Double::sum);
+        long count = values.size();
+
+        String sql = format("construct_tdigest(CAST(ROW(%s, %s, %s, %s, %s, %s, %s) AS ROW(centroid_means ARRAY<DOUBLE>, centroid_weights ARRAY<BIGINT>, compression DOUBLE, min DOUBLE, max DOUBLE, sum DOUBLE, count BIGINT)))",
+                values,
+                weights,
+                compression,
+                min,
+                max,
+                sum,
+                count);
+
+        functionAssertions.assertFunction(
+                sql,
+                SqlVarbinary,
+                new SqlVarbinary(tDigest.serialize().getBytes()));
     }
 
     @Test


### PR DESCRIPTION
Test plan - `mvn -Dtest="TestTDigest,TestTDigestFunctions" test`

Creating a function that allows users to generate a TDigest varbinary from the internal tdigest representation.


```
== RELEASE NOTES ==

General Changes
* Added CONSTRUCT_TDIGEST() for Tdigest. The prototype of the function is:

CONSTRUCT_TDIGEST(
  double[] centroidMeans,
  double[] centroidWeights,
  double compression,
  double min,
  double max,
  double sum,
  bigint count)
) -> DOUBLE
```